### PR TITLE
Fix Chatlog addon broken by commander blade bug fix.

### DIFF
--- a/Chatlog/init.lua
+++ b/Chatlog/init.lua
@@ -228,7 +228,11 @@ local function get_chat_log()
                     name, locale, msg = string.match(rawmsg, QCHAT_MATCH) -- try match again
                 end
                 -- good enough
-                table.insert(messages, {name = name, text = msg, date = "??:??:??"})
+                local sanitizedName = name
+                if pso.require_version == nil or not pso.require_version(3, 6, 0) then
+                    sanitizedName = string.gsub(name, "%%", "%%%%") -- escape '%'
+                end
+                table.insert(messages, {name = sanitizedName, text = msg, date = "??:??:??"})
             end
         end
     end
@@ -345,9 +349,15 @@ local function DoChat()
 
     -- draw messages
     for i,msg in ipairs(output_messages) do
+        local formattedText = msg.text
+        -- Escape '%' if the base plugin is not updated. If the plugin is updated, then the output
+        -- is written as-is without any additional substitutions.
+        if pso.require_version == nil or not pso.require_version(3, 6, 0) then
+            formattedText = string.gsub(msg.text, "%%", "%%%%") -- escape '%'
+        end
         local formatted = msg.formatted or
                           ( "[".. msg.date .. "] " .. string.format("%-11s", msg.name) .. -- rpad name
-                          "| " .. string.gsub(msg.text, "%%", "%%%%")) -- escape '%'
+                          "| " .. formattedText)
         msg.formatted = formatted -- cache
         local lower = string.lower(msg.text) -- for case insensitive matching
 

--- a/Chatlog/init.lua
+++ b/Chatlog/init.lua
@@ -309,7 +309,6 @@ local function DoChat()
 
         -- Check if we have a character name, can be null if we are not online yet
         character_name = get_charactername(get_gc())
-        print("character_name", character_name)
         if character_name ~= nil then
             -- apparently there's null characters in the name?
             -- so the gsub removes them


### PR DESCRIPTION
The data at AAACC0 is used for player and team data in BB. The data was wrong and the Chatlog depended on it to determine player names that sent chat messages. This could cause it to stop logging messages.

Also contains a ~3 year old workaround for crashes with percents in character names because the base plugin was passing the string in directly as the formatting string (in case players are still on older version of the plugin): https://github.com/Elixir70/psobbaddonplugin/commit/1460645d507f3cb4ea1a959ddd97e7254aaf5ee0