### PR TITLE
Rare Crash Fix

### DIFF
--- a/Chatlog/init.lua
+++ b/Chatlog/init.lua
@@ -270,6 +270,9 @@ local function get_chat_log()
                     name, locale, msg = string.match(rawmsg, QCHAT_MATCH) -- try match again
                 end
                 -- good enough
+                if name == nil then
+                    name = ""
+                end
                 local sanitizedName = name
                 if pso.require_version == nil or not pso.require_version(3, 6, 0) then
                     sanitizedName = string.gsub(name, "%%", "%%%%") -- escape '%'


### PR DESCRIPTION
When a message is sent as you are leaving a game there is a chance that rawmsg ~= nil and #rawmsg >0 on line 262 are both true but name is nil so the string.gsub on line 275 and 277 cause a crash.
<img width="837" height="272" alt="PsoBB_2025-09-05_20-04-14" src="https://github.com/user-attachments/assets/89f8253f-7b6b-4f37-886b-562b335c034e" />
