### PR TITLE
Another Rare Crash Fix

### DIFF
--- a/Chatlog/init.lua
+++ b/Chatlog/init.lua
@@ -437,6 +437,9 @@ local function DoChat()
         end
 
         -- **Format Message**
+        if formattedText == nil then
+            formattedText = ""
+        end
         local formatted = msg.formatted or (timestampPart .. nameFormat .. options.clMessageSeparator .. formattedText)
         msg.formatted = formatted -- cache result for performance
         local lower = string.lower(msg.text) -- for case-insensitive matching


### PR DESCRIPTION
I think this one happens when joining a game as a message is being sent. I joined a game and immediately after loading in I saw a white text box with no player name. I think there's also some issue with this fix or the last that causes the addon to forcibly scroll to the bottom when the bad messages happen even when no new messages are being sent. This might be because these bugged messages don't seem to actually appear in the chatlog addon window.
<img width="842" height="276" alt="PsoBB_2026-04-11_13-24-27" src="https://github.com/user-attachments/assets/d69ba6a7-7f80-4296-9190-d5fb4ea5c498" />
